### PR TITLE
Feature/template filter item

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -57,12 +57,28 @@ jQuery( document ).ready(
 					function (term) {
 						let taxName = toTitleCase( taxonomy );
 
-						appliedFilters.push(
-							`<span class = "filter-item" data-type = "${taxonomy}" data-value = "${term.value}">
-							<strong>${taxName}: </strong>${term.text}
-							<button class = "remove-filter" aria-label = "Remove ${term.text}">×</button>
-							</span>`
-						);
+						const filterItemTemplate = document.querySelector('#filter-item-template');
+
+						if (filterItemTemplate) { // use template if available
+							const newFilterItem = filterItemTemplate.content.cloneNode(true);
+							const serializer = new XMLSerializer();
+
+							newFilterItem.querySelector('.filter-item').dataset.type = taxonomy;
+							newFilterItem.querySelector('.filter-item').dataset.value = term.value;
+							newFilterItem.querySelector('.filter-label').innerHTML = `${taxName}: `;
+							newFilterItem.querySelector('.filter-value').textContent = term.text;
+
+							appliedFilters.push(serializer.serializeToString(newFilterItem));
+						} 
+						// fallback for older versions
+						else {
+							appliedFilters.push(
+								`<span class = "filter-item" data-type = "${taxonomy}" data-value = "${term.value}">
+								<strong>${taxName}: </strong>${term.text}
+								<button class = "remove-filter" aria-label = "Remove ${term.text}">×</button>
+								</span>`
+							);
+						}
 
 						dropdownFilters.push( term.text );
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -230,20 +230,69 @@ document.addEventListener(
 					}
 				);
 
+				/**
+				 * This will close the dropdown prematurely if the user clicks 
+				 * inside the dropdown.
+				 * 
+				 * Note that `dropdown-menu` is absolute positioned,
+				 * so it will be removed from the document flow.
+				 */
 				// Close dropdown when tabbing away
-				button.parentElement.addEventListener(
-					'focusout',
-					function (event) {
-						const dropdown      = this;
-						const relatedTarget = event.relatedTarget;
+				// button.parentElement.addEventListener(
+				// 	'focusout',
+				// 	function (event) {
+				// 		const dropdown      = this;
+				// 		const relatedTarget = event.relatedTarget;
 
-						// Check if the newly focused element is outside the dropdown
-						if ( ! dropdown.contains( relatedTarget )) {
-							dropdown.classList.remove( 'open' );
-							dropdown.querySelector( '.dropdown-toggle' ).setAttribute( 'aria-expanded', 'false' );
+				// 		// Check if the newly focused element is outside the dropdown
+				// 		if ( ! dropdown.contains( relatedTarget )) {
+				// 			dropdown.classList.remove( 'open' );
+				// 			dropdown.querySelector( '.dropdown-toggle' ).setAttribute( 'aria-expanded', 'false' );
+				// 		}
+				// 	}
+				// );
+
+				/**
+				 * Close the dropdown when tabbing away, we make following
+				 * considerations:
+				 * - If user is focused on the last element inside the dropdown,
+				 *  the dropdown will close when tabbing away.
+				 * - If user is focused on the first element inside the dropdown,
+				 *  the dropdown will close when tabbing away (using shift key).
+				 * 
+				 * We refer ally-collective for preffered solution:
+				 * @see https://www.a11y-collective.com/blog/mastering-web-accessibility-making-drop-down-menus-user-friendly/
+				 * 	Add awarness of when a user tabs out of the menu part 
+				 */
+
+				document.addEventListener('keydown', function (event) {
+					// handle tabbing
+					if (event.key === 'Tab') {
+						const dropdown = button.parentElement;
+						const currentFocusedElement = document.activeElement;
+						const inputCollection = dropdown.querySelectorAll('input');
+
+						const firstFocusableElement = inputCollection[0];
+						const lastFocusableElement = inputCollection[inputCollection.length - 1];
+
+						if (!event.shiftKey && currentFocusedElement === lastFocusableElement) {
+							// if tabbing forward ⏩ and focused on the last element, close the dropdown
+							dropdown.classList.remove('open');
+							dropdown.querySelector('.dropdown-toggle').setAttribute('aria-expanded', 'false');
+						} else if (event.shiftKey && currentFocusedElement === firstFocusableElement) {
+							// if tabbing backward ⏪ and focused on the first element, close the dropdown
+							dropdown.classList.remove('open');
+							dropdown.querySelector('.dropdown-toggle').setAttribute('aria-expanded', 'false');
 						}
+					} 
+					// handle escaping 
+					else if (event.key === 'Escape') {
+						// close dropdowns when pressing the Escape key
+						const dropdown = button.parentElement;
+						dropdown.classList.remove('open');
+						dropdown.querySelector('.dropdown-toggle').setAttribute('aria-expanded', 'false');
 					}
-				);
+				});
 			}
 		);
 

--- a/templates/filter-summary.php
+++ b/templates/filter-summary.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('ABSPATH')) { exit; } // Prevent direct access
+if (!defined('ABSPATH')) {
+  exit;
+} // Prevent direct access
 
 // Get count from AJAX or direct POST
 global $postsTotal;
@@ -55,12 +57,21 @@ if (!empty($filters)) {
   <!-- Resource Count -->
   <p><strong>Showing <span id="result-count"><?php echo esc_html($count); ?></span> resource(s)</strong></p>
 
-  <div class="sort-filters flex items-start gap-4">
+  <div class="flex items-start gap-4 sort-filters">
     <!-- Applied Filters -->
     <p>
       <strong>Filters applied:</strong><br>
       <span id="applied-filters"><?php echo $filterHtml; ?></span>
     </p>
+
+    <!-- template for filters -->
+    <template id="filter-item-template">
+      <li class="filter-item" data-type="" data-value="">
+        <strong class="filter-label"></strong>
+        <span class="filter-value"></span>
+        <button class="remove-filter" aria-label="Remove filter">×</button>
+      </li>
+    </template>
 
     <!-- Add target element for focus on pagination scroll -->
     <h2 tabindex="-1" class="sr-only">Search Results</h2>


### PR DESCRIPTION
Include ability to pass html markup used to build the filter items to display applied filters.

**Overview**

- Currently the html markup for applied filter items is being hardcoded in the JS served by the plugin
- This prevents the theme developers from defining the markup, for look and feel, as well as accessibility compliance

**Proposed Solution**

- Supporting the existing theme running the plugin, we provide a progressive enhancement to include a [content template](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template) that the JS can then use to populate the filter items
- This will allow customization while ensuring that when no template is provided the script fallbacks to the previous strategy

**Motivation**

- On MB Ombudsman, the site is using this plugin for reports resources
- Nicky, in her accessibility audit called out using spans instead of unordered list and `li`'s to populate the active filter list
- This change was hard to make since the markup was served via the plugin
- This lead to finding creative solutions to provide flexibility of defining markup without re-writing a good chunk of current plugin implementation

**Testing Instructions**

- In your `filter-summary.php` file include a content template outlining the markup for the filter items, see below
```
<!-- template for filters -->
  <template id="filter-item-template">
    <li class="filter-item" data-type="" data-value="">
      <strong class="filter-label"></strong>
      <span class="filter-value"></span>
      <button class="remove-filter" aria-label="Remove filter">×</button>
    </li>
  </template>
```

- Make sure the `id` on the template tag is `filter-item-template`, JS uses this to determine if the template is present and to find the document fragment
- Apply proper classes to the nested child elements, `filter-label` to include the label of the active filter, `filter-value` to include the value selected for the filter type, and `filter-item` on the wrapper for `filter-value`, `filter-label` and `remove-filter` button.